### PR TITLE
(CDAP-13020) Removed parents from JDBC driver packages. This is only …

### DIFF
--- a/packages/jdbc-driver-db2/11.1/db2-11-connector.json
+++ b/packages/jdbc-driver-db2/11.1/db2-11-connector.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "cdap-data-pipeline[3.0.0,10.0.0]",
-    "cdap-data-streams[3.0.0,10.0.0]",
-    "cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "db211",

--- a/packages/jdbc-driver-mysql-connector/5.0.8/mysql-connector-java.json
+++ b/packages/jdbc-driver-mysql-connector/5.0.8/mysql-connector-java.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "system:cdap-data-pipeline[3.0.0,10.0.0]",
-    "system:cdap-data-streams[3.0.0,10.0.0]",
-    "system:cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "mysql",

--- a/packages/jdbc-driver-mysql-connector/5.1.39/mysql-connector-java.json
+++ b/packages/jdbc-driver-mysql-connector/5.1.39/mysql-connector-java.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "system:cdap-data-pipeline[3.0.0,10.0.0]",
-    "system:cdap-data-streams[3.0.0,10.0.0]",
-    "system:cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "mysql",

--- a/packages/jdbc-driver-netezza/7.2.1/netezza-7.2.1-connector.json
+++ b/packages/jdbc-driver-netezza/7.2.1/netezza-7.2.1-connector.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "system:cdap-data-pipeline[3.0.0,10.0.0]",
-    "system:cdap-data-streams[3.0.0,10.0.0]",
-    "system:cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "netezza",

--- a/packages/jdbc-driver-oracle/12c/oracle12c-connector.json
+++ b/packages/jdbc-driver-oracle/12c/oracle12c-connector.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "system:cdap-data-pipeline[3.0.0,10.0.0]",
-    "system:cdap-data-streams[3.0.0,10.0.0]",
-    "system:cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "oracle",

--- a/packages/jdbc-driver-postgres-connector/9.4.1211.jre7/postgresql-connector.json
+++ b/packages/jdbc-driver-postgres-connector/9.4.1211.jre7/postgresql-connector.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "system:cdap-data-pipeline[3.0.0,10.0.0]",
-    "system:cdap-data-streams[3.0.0,10.0.0]",
-    "system:cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "postgresql",

--- a/packages/jdbc-driver-postgres-connector/9.4.1211.jre8/postgresql-connector.json
+++ b/packages/jdbc-driver-postgres-connector/9.4.1211.jre8/postgresql-connector.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "system:cdap-data-pipeline[3.0.0,10.0.0]",
-    "system:cdap-data-streams[3.0.0,10.0.0]",
-    "system:cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "postgresql",

--- a/packages/jdbc-driver-sqlserver/6.0.jre7/sqlserver-connector.json
+++ b/packages/jdbc-driver-sqlserver/6.0.jre7/sqlserver-connector.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "cdap-data-pipeline[3.0.0,10.0.0]",
-    "cdap-data-streams[3.0.0,10.0.0]",
-    "cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "sqlserver41",

--- a/packages/jdbc-driver-sqlserver/6.0.jre8/sqlserver-connector.json
+++ b/packages/jdbc-driver-sqlserver/6.0.jre8/sqlserver-connector.json
@@ -1,9 +1,4 @@
 {
-  "parents": [
-    "cdap-data-pipeline[3.0.0,10.0.0]",
-    "cdap-data-streams[3.0.0,10.0.0]",
-    "cdap-etl-batch[3.0.0,10.0.0]"
-  ],
   "plugins": [
     {
       "name" : "sqlserver42",


### PR DESCRIPTION
…a cleanup, and not an incompatible change, because the UI never actually used this parent section from the JSONs for JDBC drivers. Hence, only updated existing versions and did not create new versions

Build: https://builds.cask.co/browse/CMP-BSPD30-1