### PR TITLE
adding datapacks back to 5.1.0 until UI has filter logic

### DIFF
--- a/packages/datapack-access-log/1.0.0/spec.json
+++ b/packages/datapack-access-log/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "Sample access logs in Combined Log Format (CLF).",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1473901763,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-browser-mapping/1.0.0/spec.json
+++ b/packages/datapack-browser-mapping/1.0.0/spec.json
@@ -5,7 +5,6 @@
   "author": "Cask",
   "org": "Cask Data, Inc.",
   "created": 1473901763,
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "categories": [ "datapack" ],
   "actions": [
     {

--- a/packages/datapack-contacts/1.0.0/spec.json
+++ b/packages/datapack-contacts/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "Sample contact data in CSV format.",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1473901763,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-crunchbase-organizations/1.0.0/spec.json
+++ b/packages/datapack-crunchbase-organizations/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "CSV-formatted organization data from Crunchbase.",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1473901763,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-news-feed/1.0.0/spec.json
+++ b/packages/datapack-news-feed/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "A sample of the world news RSS feed from the New York Times in XML format.",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1474681358,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-omniture-hits/1.0.0/spec.json
+++ b/packages/datapack-omniture-hits/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "Omniture clicks and hits sample dataset.",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1473901763,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-realestate-listings/1.0.0/spec.json
+++ b/packages/datapack-realestate-listings/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "Sample of home listings made in a few Bay Area cities in 2017.",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1532482912,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-realestate-sales/1.0.0/spec.json
+++ b/packages/datapack-realestate-sales/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "Sample of home sales made in a few Bay Area cities in 2017.",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1532482912,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-spam-labeled-sms-texts/1.0.0/spec.json
+++ b/packages/datapack-spam-labeled-sms-texts/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "SMS texts that have been labeled as either 'spam' or 'ham'.",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1474060461,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-tweets-sample-labeled/1.0.0/spec.json
+++ b/packages/datapack-tweets-sample-labeled/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "Sample of tweets, labeled as negative (0), neutral (2), or positive (4).",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1474312686,
   "categories": [ "datapack" ],
   "actions": [

--- a/packages/datapack-tweets-sample-raw/1.0.0/spec.json
+++ b/packages/datapack-tweets-sample-raw/1.0.0/spec.json
@@ -4,7 +4,6 @@
   "description": "Sample of raw tweets.",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0,5.1.0-SNAPSHOT)",
   "created": 1474312686,
   "categories": [ "datapack" ],
   "actions": [


### PR DESCRIPTION
Datapacks need to remain because the datapack category is
hardcoded in the UI in older versions of CDAP. But the UI also
does not have logic to hide the category if it exists but there
are no packages for that specific CDAP version.

Until that logic is there, datapacks must be visible.